### PR TITLE
Adicionando redes sociais ao author_card

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ adicionar os arquivos ao blog seguindo os passos descritos a seguir
 {
     "name": "Seu nome",
     "image": "/images/authors/username_no_github.jpg",
-    "description":"breve descrição"
+    "description":"breve descrição",
+    "social": {
+        "github": "https://github.com/username_no_github",
+        "twitter": "https://twitter.com/username_no_twitter",
+        "linkedin": "https://br.linkedin.com/in/username_no_linkedin"
+    }
 }
 ```
 

--- a/content/authors/turicas.json
+++ b/content/authors/turicas.json
@@ -1,5 +1,10 @@
 {
     "name": "Álvaro Justen",
     "image": "/images/authors/turicas.jpg",
-    "description": "Álvaro Justen é programador, professor e empreendedor. Ativista de software livre e de dados abertos, desenvolve e gerencia projetos de captura e análise de dados (principalmente públicos), majoritariamente com Python; adora compartilhar conhecimento e colabora com a comunidade de jornalismo de dados brasileira; é fundador do portal de dados abertos acessíveis Brasil.IO e quando não está programando ou dando aulas, viaja, prova e torra cafés especiais."
+    "description": "Álvaro Justen é programador, professor e empreendedor. Ativista de software livre e de dados abertos, desenvolve e gerencia projetos de captura e análise de dados (principalmente públicos), majoritariamente com Python; adora compartilhar conhecimento e colabora com a comunidade de jornalismo de dados brasileira; é fundador do portal de dados abertos acessíveis Brasil.IO e quando não está programando ou dando aulas, viaja, prova e torra cafés especiais.",
+    "social": {
+        "github": "https://github.com/turicas",
+        "twitter": "https://twitter.com/turicas",
+        "linkedin": "https://br.linkedin.com/in/alvarojusten"
+    }
 }

--- a/themes/pelican-alchemy/alchemy/templates/include/author_card.html
+++ b/themes/pelican-alchemy/alchemy/templates/include/author_card.html
@@ -4,9 +4,9 @@
   <div class="row pt-2">
     {% for author in article.authors %}
       <div class="card col-sm-12 mx-auto mb-2 p-2">
-        <div class="card-body row pt-3 px-2">
-          <div class="col-12 col-md-4">
-            <img class="rounded-circle mx-auto d-block align-middle"
+        <div class="card-body row pt-3 px-2">          
+          <div class="col-12 col-md-4 my-auto text-center">
+            <img class="rounded-circle mx-auto d-block" 
                 {% if AUTHOR_DETAIL[author|string]['image'] %}
                   src="{{ AUTHOR_DETAIL[author|string]['image'] }}" alt="{{ author }}"
                 {% else %}
@@ -15,11 +15,16 @@
                 alt="avatar"
                 width="150"
             />
+            {% for social, url in AUTHOR_DETAIL[author|string]['social'].items() %}
+            <a href="{{url}}" target="_blank" title="{{social}} de {{author}} " class="mt-3 px-1" style="text-decoration: none;">
+              <i class="fa fa-{{social}} my-2" style="font-size:22px; color:rgb(78, 78, 78)"></i>
+            </a>
+            {% endfor %}
           </div>
           <div class="col-12 col-md-8">
             <div class="mt-3">
-              <h5 class="card-title">{{ AUTHOR_DETAIL[author|string]['name'] }}</h5>
-              <div style="max-width:540x">
+              <h5 class="card-title">{{AUTHOR_DETAIL[author|string]['name']}}</h5>
+              <div style="max-width:500px">
                 <span class="card-text">
                   {{ AUTHOR_DETAIL[author|string]['description'] }}
                 </span>


### PR DESCRIPTION
Atualização para exibição de redes sociais ao final do post no card de autor.

Segue imagem de resultado:

![image](https://user-images.githubusercontent.com/26860387/113643262-4e4eaf00-9658-11eb-94f6-e59e8b3bfe48.png)

As informações são puxadas diretamente do .json do author bastando referir as redes e as urls para que no template sejam exibidas utilizando os icones do fontawesome.